### PR TITLE
Attempt to merge changes with PR#1814

### DIFF
--- a/public/js/Counter.js
+++ b/public/js/Counter.js
@@ -101,31 +101,28 @@ Counter.prototype.customDraw = function () {
     ctx.stroke();
 }
 
-//add this to output the modue
 Counter.moduleVerilog = function () {
-    var output = "";
-    output += "\n";
-    output += "module Counter(val, zero, max, clk, rst);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] val;\n";
-    output += "  output reg zero;\n";
-    output += "  input [WIDTH-1:0] max;\n";
-    output += "  input clk, rst;\n";
-    output += "\n";  
-    output += "  always @ (posedge clk or posedge rst)\n";
-    output += "    if (rst)\n";
-    output += "      val <= 'b0;\n";
-    output += "    else begin\n";
-    output += "      if (val < max) begin\n";
-    output += "        val <= val + 1;\n";
-    output += "        zero <= 0;\n";
-    output += "      end \n";
-    output += "      else begin\n";
-    output += "        val <= 0;\n";
-    output += "        zero <= 1;\n";
-    output += "      end\n";
-    output += "    end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
+    return `
+module Counter(val, zero, max, clk, rst);
+parameter WIDTH = 1;
+output reg [WIDTH-1:0] val;
+output reg zero;
+input [WIDTH-1:0] max;
+input clk, rst;
+
+always @ (posedge clk or posedge rst)
+  if (rst)
+    val <= 'b0;
+  else begin
+    if (val < max) begin
+      val <= val + 1;
+      zero <= 0;
+    end 
+    else begin
+      val <= 0;
+      zero <= 1;
+    end
+  end
+endmodule
+`;
 }

--- a/public/js/logix.js
+++ b/public/js/logix.js
@@ -1440,11 +1440,11 @@ CircuitElement.prototype.processVerilog = function() {
                 || (this.verilogLabel + "_" + (verilog.fixNameInv(this.nodeList[i].label) 
                 || ((output_total>1)?"out_" + output_count:"out")));
             if (this.objectType != "Input" && this.nodeList[i].connections.length > 0) {
-                if (this.scope.verilogWireList[this.bitWidth] != undefined) {
-                    if (!this.scope.verilogWireList[this.bitWidth].contains(this.nodeList[i].verilogLabel))
-                        this.scope.verilogWireList[this.bitWidth].push(this.nodeList[i].verilogLabel);
+                if (this.scope.verilogWireList[this.nodeList[i].bitWidth] != undefined) {
+                    if (!this.scope.verilogWireList[this.nodeList[i].bitWidth].contains(this.nodeList[i].verilogLabel))
+                        this.scope.verilogWireList[this.nodeList[i].bitWidth].push(this.nodeList[i].verilogLabel);
                 } else
-                    this.scope.verilogWireList[this.bitWidth] = [this.nodeList[i].verilogLabel];
+                    this.scope.verilogWireList[this.nodeList[i].bitWidth] = [this.nodeList[i].verilogLabel];
             }
             this.scope.stack.push(this.nodeList[i]);
             output_count++;
@@ -1491,7 +1491,7 @@ CircuitElement.prototype.verilogName = function() {
     return this.verilogType || this.objectType;
 }
 
-CircuitElement.prototype.generateVerilog = function() {
+CircuitElement.prototype.generateVerilog = function(tag) {
     var inputs = [];
     var outputs = [];
 
@@ -1508,11 +1508,14 @@ CircuitElement.prototype.generateVerilog = function() {
     var list = outputs.concat(inputs);
     var res = this.verilogName();
 
+    if (tag != undefined)
+        res += tag;
+
     //add this for mult-bit inputs
     if (this.bitWidth != undefined && this.bitWidth > 1)
       res += " #(" + this.bitWidth + ")";
 
-    res += " " + this.verilogLabel + "(" + list.map(function(x) {
+    res += " " + this.verilogLabel  + "(" + list.map(function(x) {
         return x.verilogLabel
     }).join(", ") + ");";
 

--- a/public/js/sequential.js
+++ b/public/js/sequential.js
@@ -51,29 +51,29 @@ TflipFlop.prototype.isResolvable = function() {
     if (this.clockInp.value != undefined && this.dInp.value != undefined) return true;
     return false;
 }
-//add this to output the modue
-TflipFlop.moduleVerilog = function() {
-    var output = "";
-    output += "\n";
-    output += "module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
-    output += "  input clk, a_rst, pre, en;\n";
-    output += "  input [WIDTH-1:0] t;\n";
-    output += "  \n";
-    output += "  always @ (posedge clk or posedge a_rst)\n";
-    output += "    if (a_rst) begin\n";
-    output += "      q <= 'b0;\n";
-    output += "      q_inv <= 'b1;\n";
-    output += "    end else if (en == 0) ;\n";
-    output += "    else if (t) begin\n";
-    output += "      q <= q ^ t;\n";
-    output += "      q_inv <= ~q ^ t;\n";
-    output += "    end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
+
+//add this to output the module
+TflipFlop.moduleVerilog = function(){
+return `
+module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
+  parameter WIDTH = 1;
+  output reg [WIDTH-1:0] q, q_inv;
+  input clk, a_rst, pre, en;
+  input [WIDTH-1:0] t;
+  
+  always @ (posedge clk or posedge a_rst)
+    if (a_rst) begin
+      q <= 'b0;
+      q_inv <= 'b1;
+    end else if (en == 0) ;
+    else if (t) begin
+      q <= q ^ t;
+      q_inv <= ~q ^ t;
+    end
+endmodule
+`
 }
+
 TflipFlop.prototype.newBitWidth = function(bitWidth) {
     this.bitWidth = bitWidth;
     this.dInp.bitWidth = bitWidth;
@@ -223,28 +223,27 @@ DflipFlop.prototype.resolve = function() {
         simulationArea.simulationQueue.add(this.qInvOutput);
     }
 }
-//add this to output the modue
-DflipFlop.moduleVerilog = function() {
-    var output = "";
-    output += "\n";
-    output += "module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] q, q_inv;\n";
-    output += "  input clk, a_rst, pre, en;\n";
-    output += "  input [WIDTH-1:0] d;\n";
-    output += "  \n";
-    output += "  always @ (posedge clk or posedge a_rst)\n";
-    output += "    if (a_rst) begin\n";
-    output += "      q <= 'b0;\n";
-    output += "      q_inv <= 'b1;\n";
-    output += "    end else if (en == 0) ;\n";
-    output += "    else begin\n";
-    output += "      q <= d;\n";
-    output += "      q_inv <= ~d;\n";
-    output += "    end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
+
+//add this to output the module
+DflipFlop.moduleVerilog = function(){
+    return `
+module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);
+  parameter WIDTH = 1;
+  output reg [WIDTH-1:0] q, q_inv;
+  input clk, a_rst, pre, en;
+  input [WIDTH-1:0] d;
+  
+  always @ (posedge clk or posedge a_rst)
+    if (a_rst) begin
+      q <= 'b0;
+      q_inv <= 'b1;
+    end else if (en == 0) ;
+    else begin
+      q <= d;
+      q_inv <= ~d;
+    end
+endmodule
+`
 }
 DflipFlop.prototype.customSave = function() {
     var data = {
@@ -460,23 +459,23 @@ Random.prototype.customDraw = function() {
 
 }
 
-//add this to output the modue
-Random.moduleVerilog = function () {
-    var output = "";
-    output += "\n";
-    output += "module Random(val, clk, max);\n";
-    output += "  parameter WIDTH = 1;\n";
-    output += "  output reg [WIDTH-1:0] val;\n";
-    output += "  input clk;\n";
-    output += "  input [WIDTH-1:0] max;\n";
-    output += "\n";
-    output += "  always @ (posedge clk)\n";
-    output += "    val = $urandom_range(0, max);\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
-}
 
+Random.moduleVerilog = function () {
+  return `
+module Random(val, clk, max);
+  parameter WIDTH = 1;
+  output reg [WIDTH-1:0] val;
+  input clk;
+  input [WIDTH-1:0] max;
+
+  always @ (posedge clk)
+    if (^max === 1'bX)
+      val = $urandom();
+    else
+      val = $urandom_range(0, max);
+endmodule
+`;
+}
 
 function SRflipFlop(x, y, scope = globalScope, dir = "RIGHT") {
     CircuitElement.call(this, x, y, scope, dir, 1);
@@ -1053,21 +1052,18 @@ Clock.prototype.customDraw = function() {
     ctx.stroke();
 
 }
-// This code is for internal clock, may reactivate
 /*
 Clock.moduleVerilog = function() {
-    var output = "";
-    output += "\n";
-    output += "module Clock(clk);\n";
-    output += "  output reg clk;\n";
-    output += "  always begin\n";
-    output += "    #10\n";
-    output += "    clk=1'b0;\n";
-    output += "    #10\n";
-    output += "    clk=1'b0;\n";
-    output += "  end\n";
-    output += "endmodule\n";
-    output += "\n";
-    return output;
+    return `
+module Clock(clk);
+  output reg clk;
+  always begin
+    #10
+    clk=1'b0;
+    #10
+    clk=1'b0;
+  end
+endmodule
+`
 }
 */

--- a/public/js/subcircuit.js
+++ b/public/js/subcircuit.js
@@ -375,7 +375,7 @@ SubCircuit.prototype.generateVerilog = function() {
 }
 
 SubCircuit.prototype.verilogName = function() {
-    return verilog.fixName(scopeList[this.id].name);
+    return verilog.santizeLabel(scopeList[this.id].name);
 }
 
 SubCircuit.prototype.customDraw = function() {

--- a/public/js/verilog.js
+++ b/public/js/verilog.js
@@ -64,7 +64,7 @@ verilog = {
         completed[id] = true;
 
         var scope = scopeList[id];
-    	// This part is explicitely added to add the SubCircuit and process its outputs
+    	// This part is explicitely added to add the Clock and process its outputs
         for(var i = 0; i < scope.Clock.length; i++) {
 //            console.log(scope.Clock[i].label);
             if (scope.Clock[i].label == "") {
@@ -313,5 +313,20 @@ verilog = {
     },
     fixName: function(name){
         return name.replace(/ /g , "_");
+    },
+    santizeLabel: function(name){
+        return name.replace(/ Inverse/g, "_inv").replace(/ /g , "_");
+    },
+    generateNodeName: function(node, currentCount, totalCount) {
+        if (node.verilogLabel) return node.verilogLabel;
+        var parentVerilogLabel = node.parent.verilogLabel;
+        var nodeName;
+        if(node.label) {
+            nodeName = verilog.santizeLabel(node.label);
+        }
+        else {
+            nodeName = (totalCount > 1) ? "out_" + currentCount: "out";
+        }
+        return parentVerilogLabel + "_" + nodeName;
     }
 }


### PR DESCRIPTION
verilog.js fixed minor bug, but unable to PR1814
logix.js added tag in CircuitElement.prototype.generateVerilog so it takes tag - because unable to incorporate verilog.js, unable to use PR#1814
module.js has minor changes to write tag, otherwise same as PR#1814
Counter, sequential, subcircuit incorporated most changes in PR#1814

Problems:
  Clock is translated as input, PR#1814 does not do this
  Splitter is very hard to get to work properly.  I used a lot of trial and error with verilog.js and logix.js. The change in code from PR#1814 made these changes not work.

Specific errors:
  Splitter inputs need to be a single variable with bitwidth, sometimes this is to the case
  Splitter output sometimes disappear completely, because of DFS from input of module, and sometimes splitter input is connected to an input of device or module
  Making Clock an Input of the module sometimes resulted in it being an output or wire

I think the Splitter and Clock logic needs to be reworked so PR#1814 can work well
I have tried to incorporate as much of the changes as I can
Thanks,
James

Fixes #

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 
